### PR TITLE
Instead of settings.ini report_prefix and report_dir will be passed t…

### DIFF
--- a/src/guify/App.py
+++ b/src/guify/App.py
@@ -10,15 +10,23 @@ from pymsgbox import alert
 log = logging.getLogger("\tindex.py")
 worker = TestWorker()
 
-
 class GUIfy:
-    def __init__(self, app_name='GUIfy', port=8080):
+    # report_dir is the directory of the reports
+    
+    # report_prefix is the prefix of the report file
+    # report_prefix can be set to one of the arguments
+    # that is required by registered functions. For example:
+    # if a registered function requires argument name and age
+    # then report_prefix can be set to 'name' or 'age'.
+    def __init__(self, app_name='GUIfy', port=8080, report_dir=None, report_prefix=None):
         self._port = port
         self._app_name = app_name
         eel.expose(self.app_name)
+        worker._report_dir = report_dir
+        worker._report_prefix = report_prefix
         self.worker = worker
-        self.monitor = worker.monitor
-        self.config = worker.config_tab
+        self.monitor = self.worker.monitor
+        self.config = self.worker.config_tab
 
     def app_name(self):
         return self._app_name

--- a/src/guify/__init__.py
+++ b/src/guify/__init__.py
@@ -59,7 +59,6 @@ def all_tests():
 
 @eel.expose
 def worker_status():
-    log.debug(f"worker_status called")
     return {
         "state": worker.state,
         "currentJob": worker.currently_running,


### PR DESCRIPTION
Instead of settings.ini, report_dir and report_prefix, will be passed to the constructor of GUIfy
If report_dir is none, report generation is off
report_dir can be relative or absolute path.
report_prefix can be set to one of the args of the registered functions.