### PR TITLE
print(str) will now print to "monitor"

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,11 +17,11 @@ pip install guify
 import GUIfy from guify
 
 # Instantiate the app, variables are optional.
-# app_name is the title of the app shown on the top, equivalent to <title /> tag in HTML
-# report_dir is the directory where reports will be stored
-# report_prefix is the prefix of the report, if none, it will be 'report'
-# if set to 'serial_number', this will be requested in the gui.
-app = GUIfy(app_name='GUIfy', port=8080, report_dir=None, report_prefix=None) # default app_name is 'GUIfy'
+# - app_name is the title of the app shown on the top, equivalent to <title /> tag in HTML
+# - report_dir is the directory where reports will be stored if none reports are disabled.
+# - report_prefix // the name of the variable to take the prefix from, default is "report_*.txt"
+# - redirect_stdout // if True, will redirect stdout to the monitor, default is True
+app = GUIfy(app_name='GUIfy', port=8080, report_dir=None, report_prefix=None, redirect_stdout=True) # default app_name is 'GUIfy'
 
 # Register the function "test_1"
 # All variables are optional
@@ -38,10 +38,10 @@ def test_1(example_arg):
     app.monitor.clear_text()
 
     # app.monitor.set_text(text) - sets the text to whatever is passed to it
-    app.monitor.set_text('This is a test\n')
+    app.monitor.write('This is a test\n')
 
-    # app.monitor.append_text(text) - appends whatever passed to it to the textarea
-    app.monitor.append_text('This is a test2\n')
+    # print function will also print to the monitor
+    print('This is a test2\n')
 
     # app.prompt_user(prompt) - pops up a modal in the gui and asks user to click OK or cancel.
     # app.prompt_user will return True if user clicked OK and False if user clicked cancel
@@ -76,7 +76,7 @@ app.run()
 app.monitor is the monitor object representing the preview window on right hand side of the GUI,
 
 - set_text(text: str) -> None // will set the text in the monitor to whatever passed in "text" argument
-- append_text(text: str) -> None // will append the next to the monitor
+- write(text: str) -> None // will append the next to the monitor, print() also works
 - clear_text(text: str) -> None // will clear all text in the monitor
 
 ---
@@ -117,5 +117,4 @@ Theoretically its possible to build an executable with eel using the following:
 ```bash
 py -m eel index.py build --onefile --noconsole --name <whatever_u_want> --icon=public/favicon.ico
 ```
-
-Please not that this hasn't been tested yet.
+Please note that eel build hasn't been tested yet.

--- a/docs/example.py
+++ b/docs/example.py
@@ -14,15 +14,15 @@ app = guify.GUIfy()
 
 @app.register(priority=1, name="test 1", description="test1")
 def test1(test_arg):
-    app.monitor.append_text("Running test1\n")
-    app.monitor.append_text(str(app.prompt_user(test_arg)) + "\n")
+    print("Running test1\n")
+    print(str(app.prompt_user(test_arg)) + "\n")
 
     return True
 
 
 @app.register(priority=0, name="test 2", description="test2")
 def test2(test_arg2):
-    app.monitor.append_text("Running test2\n")
+    print("Running test2\n")
 
     return True
 

--- a/run_debug.py
+++ b/run_debug.py
@@ -13,7 +13,7 @@ if DEBUG:
         app_mode=False,
         debug=True
     )
-app = GUIfy("Testing GUIfy")
+app = GUIfy("Testing GUIfy", redirect_stdout=True)
 # app:
 # app.config.get('example', 'foo') -> 'bar' (from config.ini)
 # app.config.get_section('example') -> {'foo': 'bar'} (from config.ini)
@@ -27,15 +27,13 @@ app = GUIfy("Testing GUIfy")
 
 @app.register(priority=1, name="test 1", description="test1")
 def test1(test_arg):
-    app.monitor.append_text("Running test1\n")
-    app.monitor.append_text(str(app.prompt_user(test_arg)) + "\n")
-
+    print("Running test!")
+    raise Exception("Test exception")
     return True
 
 
 @app.register(priority=0, name="test 2", description="test2")
 def test2(test_arg2):
-    app.monitor.append_text("Running test2\n")
 
     return True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = guify
-version = 0.2.8-rc0
+version = 0.2.8
 author = Michael Druyan
 author_email = michael@druyan.net
 description = A tool that will GUI-ify your functions

--- a/src/guify/App.py
+++ b/src/guify/App.py
@@ -10,15 +10,16 @@ from pymsgbox import alert
 log = logging.getLogger("\tindex.py")
 worker = TestWorker()
 
+
 class GUIfy:
     # report_dir is the directory of the reports
-    
+
     # report_prefix is the prefix of the report file
     # report_prefix can be set to one of the arguments
     # that is required by registered functions. For example:
     # if a registered function requires argument name and age
     # then report_prefix can be set to 'name' or 'age'.
-    def __init__(self, app_name='GUIfy', port=8080, report_dir=None, report_prefix=None):
+    def __init__(self, app_name='GUIfy', port=8080, report_dir=None, report_prefix=None, redirect_stdout=True):
         self._port = port
         self._app_name = app_name
         eel.expose(self.app_name)
@@ -27,6 +28,9 @@ class GUIfy:
         self.worker = worker
         self.monitor = self.worker.monitor
         self.config = self.worker.config_tab
+
+        if redirect_stdout:
+            sys.stdout = self.monitor
 
     def app_name(self):
         return self._app_name

--- a/src/guify/Monitor.py
+++ b/src/guify/Monitor.py
@@ -8,7 +8,7 @@ class Monitor:
     def set_text(self, text):
         eel.set_text(text)
 
-    def append_text(self, text):
+    def write(self, text):
         self.text += str(text)
         eel.set_text(self.text)
 

--- a/src/guify/TestWorker.py
+++ b/src/guify/TestWorker.py
@@ -9,6 +9,7 @@ import logging
 from .constants import OK, CANCEL, WAITING_FOR_RUN, RUNNING_TEST, PENDING_USER_INPUT, DONE
 from .Monitor import Monitor
 from .ConfigTab import ConfigTab
+import traceback
 
 CFG_FILE_NAME = 'settings.ini'
 DEFAULT_REPORTS_FOLDER_NAME = 'reports'
@@ -77,7 +78,7 @@ class TestWorker(Thread):
         if self._report_dir is None:
             log.debug("No report directory set, report generation is off")
             return None
-        
+
         if os.path.isabs(self._report_dir):
             retval = self._report_dir
         else:
@@ -160,9 +161,10 @@ class TestWorker(Thread):
             return result
 
         except Exception as exc:
-            exc_str = f"Exception: {exc} in {test._name}"
-            log.error(exc_str)
 
+            exc_str = f"{exc.__class__.__name__}: {exc} in {test._name}"
+            log.error(exc_str)
+            print(traceback.format_exc())
             self.stop()
 
             self.set_prompt(exc_str)


### PR DESCRIPTION
- Replaced monitor.append_text with write(),
- Added constructor argument "redirect_stdout", default to True.
- redirecting stdout by default to monitor.write() this means print() will now print to monitor.
- changed readme and example
